### PR TITLE
Fix: The tester for "ft_lstmap" was not compiling

### DIFF
--- a/tests/Bonus_functions/ft_lstmap/main.c
+++ b/tests/Bonus_functions/ft_lstmap/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jtoty <jtoty@student.42.fr>                +#+  +:+       +#+        */
+/*   By: dyamen <dyamen@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2017/02/28 15:16:21 by jtoty             #+#    #+#             */
-/*   Updated: 2021/02/04 07:58:38 by lmartin          ###   ########.fr       */
+/*   Updated: 2023/10/22 18:20:34 by dyamen           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,14 +90,11 @@ int main(int argc, const char *argv[])
 			return (0);
 		if (list == elem)
 			write(1, "A new list is not returned\n", 27);
-		int i;
-		i = 0;
 		ft_print_result(list);
 		while (list->next)
 		{
 			list = list->next;
 			ft_print_result(list);
-			i++;
 		}
 	}
 	return (0);


### PR DESCRIPTION
The tester for `ft_lstmap` was not compiling.

I removed the set but unsused variable `i` that was preventing the compilation of the tester due to the compiler flag `-Wunused-but-set-variable`.