### PR TITLE
Remove `-fsanitize=address`

### DIFF
--- a/srcs/check_compilation.sh
+++ b/srcs/check_compilation.sh
@@ -18,8 +18,8 @@ compilation()
 	then
 		rm -f "${PATH_TEST}"/user_exe
 	fi
-	printf "$> clang -Wextra -Wall -Werror -g3 $1 main.c libft.a -o user_exe\n\n" >> "${PATH_DEEPTHOUGHT}"/deepthought
-	clang -Wextra -Wall -Werror -g3 "${PATH_TEST}"/dirlibft/${SRC_DIR}/$1 \
+	printf "$> clang -Wextra -Wall -Werror -g3 -fsanitize=address $1 main.c libft.a -o user_exe\n\n" >> "${PATH_DEEPTHOUGHT}"/deepthought
+	clang -Wextra -Wall -Werror -g3 -fsanitize=address "${PATH_TEST}"/dirlibft/${SRC_DIR}/$1 \
 		  "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/main.c \
 		  -I "${PATH_LIBFT}"/${HEADER_DIR}/ \
 		  "${PATH_TEST}"/dirlibft/libft.a 2>>"${PATH_DEEPTHOUGHT}"/deepthought -o user_exe

--- a/srcs/check_compilation.sh
+++ b/srcs/check_compilation.sh
@@ -18,8 +18,8 @@ compilation()
 	then
 		rm -f "${PATH_TEST}"/user_exe
 	fi
-	printf "$> clang -Wextra -Wall -Werror -g3 -fsanitize=address $1 main.c libft.a -o user_exe\n\n" >> "${PATH_DEEPTHOUGHT}"/deepthought
-	clang -Wextra -Wall -Werror -g3 -fsanitize=address "${PATH_TEST}"/dirlibft/${SRC_DIR}/$1 \
+	printf "$> clang -Wextra -Wall -Werror -g3 $1 main.c libft.a -o user_exe\n\n" >> "${PATH_DEEPTHOUGHT}"/deepthought
+	clang -Wextra -Wall -Werror -g3 "${PATH_TEST}"/dirlibft/${SRC_DIR}/$1 \
 		  "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/main.c \
 		  -I "${PATH_LIBFT}"/${HEADER_DIR}/ \
 		  "${PATH_TEST}"/dirlibft/libft.a 2>>"${PATH_DEEPTHOUGHT}"/deepthought -o user_exe

--- a/srcs/diff_test.sh
+++ b/srcs/diff_test.sh
@@ -6,7 +6,7 @@
 #    By: jtoty <jtoty@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2017/01/23 18:26:48 by jtoty             #+#    #+#              #
-#    Updated: 2022/01/22 17:48:18 by fsoares-         ###   ########.fr        #
+#    Updated: 2024/05/15 22:11:54 by fdikarev         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -36,9 +36,14 @@ diff_test()
 		if [ $(( $k%2 )) -eq 1 ] && ([ $1 == "ft_putchar_fd.c" ] || [ $1 == "ft_putstr_fd.c" ] || [ $1 == "ft_putendl_fd.c" ] || [ $1 == "ft_putnbr_fd.c" ])
 		then
 			#"${PATH_TEST}"/user_exe $k > "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1)/user_output_test${text}$k 2>&1
-			"${PATH_TEST}"/user_exe $k > /dev/null 2> "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/user_output_test${text}$k
+			# Use `setarch --addr-no-randomize` to address issue with address-sanitizer
+			# and use `$(uname -m)` to be compatible with pre 2.33 version of `setarch` where `arch` argument was required.
+			# See https://github.com/google/sanitizers/issues/856
+			# and https://github.com/0x050f/libft-war-machine/pull/47
+			# for more details.
+			setarch $(uname -m) --addr-no-randomize "${PATH_TEST}"/user_exe $k > /dev/null 2> "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/user_output_test${text}$k
 		else
-			"${PATH_TEST}"/user_exe $k > "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/user_output_test${text}$k
+			setarch $(uname -m) --addr-no-randomize "${PATH_TEST}"/user_exe $k > "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/user_output_test${text}$k
 		fi
 		SIG=$?
 		if [ $SIG -eq 134 ]


### PR DESCRIPTION
There are some know issues with address sanitizer: https://github.com/google/sanitizers/issues/856

and that results to issues with the testing code: https://github.com/0x050f/libft-war-machine/issues/44 and https://github.com/0x050f/libft-war-machine/issues/46 as an example.

I faced the same issue running tests for my code. The bad part it happens randomly:
```diff
git diff diff_test.sh
diff --git a/srcs/diff_test.sh b/srcs/diff_test.sh
index 3c6b031..ab888e1 100755
@@ -55,6 +55,7 @@ diff_test()
                then
                        printf "Command './user_exe ${text}$k' got killed by a Segmentation fault\n" >> "${PATH_DEEPTHOUGHT}"/deepthought
                        printf "${COLOR_FAIL}S${DEFAULT}"
+                       cp "${PATH_TEST}/user_exe" "$HOME/user_exe_$k"
                        retvalue=0
                elif [ $SIG -eq 142 ]
                then
```
and after failed test when I run it locally:
```shell
fe@fe-air11 ~ % ./user_exe_7 7
zsh: segmentation fault (core dumped)  ./user_exe_7 7
fe@fe-air11 ~ % ./user_exe_7 7
11111%
fe@fe-air11 ~ % ./user_exe_7 7
11111%
fe@fe-air11 ~ % ./user_exe_7 7
zsh: segmentation fault (core dumped)  ./user_exe_7 7
```
after that I checked for coredumps and found them:
```shell
> coredumpctl
...
Fri 2024-05-03 07:15:28 CEST 18641 1000 1000 SIGSEGV present  /home/fe/francinette/temp/libft/war-machine/user_exe     139.8K
Fri 2024-05-03 07:19:24 CEST 18919 1000 1000 SIGSEGV present  /home/fe/francinette/temp/libft/war-machine/user_exe     139.9K
...
```
I cant find now where it happened, but when I open one of the core files with gdb:
```
> coredumpctl gdb user_exe_6
```
it gave me a link to the address-sanitizer issue.

After disabling address sanitizer, all my test passed perfectly. 